### PR TITLE
Fix errors on API 27

### DIFF
--- a/library/src/androidTest/java/lab/galaxy/yahfa/HookingTest.java
+++ b/library/src/androidTest/java/lab/galaxy/yahfa/HookingTest.java
@@ -1,6 +1,8 @@
 package lab.galaxy.yahfa;
 
+import android.os.Build;
 import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,6 +55,7 @@ public class HookingTest {
 
     @Before
     public void setup() {
+        Log.i(TAG, "ABI=" + Build.CPU_ABI);
         StaticHook.targetCount = 0;
         StaticHook.hookCount = 0;
         StaticHook.backupCount = 0;

--- a/library/src/main/jni/HookMain.c
+++ b/library/src/main/jni/HookMain.c
@@ -142,7 +142,7 @@ static int doBackupAndHook(void *targetMethod, void *hookMethod, void *backupMet
     }
 
     if(backupMethod) {// do method backup
-        if(SDKVersion < ANDROID_P) {
+        if(SDKVersion < ANDROID_O2) {
             // update the cached method manually
             // first we find the array of cached methods
             void *dexCacheResolvedMethods = (void *) readAddr(


### PR DESCRIPTION
This is the workaround suggested on #76, and it works perfectly.

I've sucessfully tested it on all supported plaforms (x86/x86_64 was tested on the emulator and arm/arm64 was tested on a Pixel 2)