### PR TITLE
[MethodResolve]use java to fix method resolve(6.0.1 ARM64,6.0.1 ARM32…

### DIFF
--- a/library/src/main/java/lab/galaxy/yahfa/HookMain.java
+++ b/library/src/main/java/lab/galaxy/yahfa/HookMain.java
@@ -21,6 +21,7 @@ public class HookMain {
     static {
         System.loadLibrary("yahfa");
         init(android.os.Build.VERSION.SDK_INT);
+        HookMethodResolver.init();
     }
 
     public static void doHookDefault(ClassLoader patchClassLoader, ClassLoader originClassLoader) {
@@ -105,6 +106,9 @@ public class HookMain {
             // backup is just a placeholder and the constraint could be less strict
             checkCompatibleMethods(target, backup, "Original", "Backup");
         }
+        if (backup != null) {
+            HookMethodResolver.resolveMethod(hook, backup);
+        }
         if (!backupAndHookNative(target, hook, backup)) {
             throw new RuntimeException("Failed to hook " + target + " with " + hook);
         }
@@ -168,6 +172,8 @@ public class HookMain {
     }
 
     private static native boolean backupAndHookNative(Object target, Method hook, Method backup);
+
+    public static native void ensureMethodCached(Method hook, Method backup);
 
     // JNI.ToReflectedMethod() could return either Method or Constructor
     public static native Object findMethodNative(Class targetClass, String methodName, String methodSig);

--- a/library/src/main/java/lab/galaxy/yahfa/HookMethodResolver.java
+++ b/library/src/main/java/lab/galaxy/yahfa/HookMethodResolver.java
@@ -1,0 +1,115 @@
+package lab.galaxy.yahfa;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * create by Swift Gan on 14/01/2019
+ * To ensure method in resolved cache
+ */
+
+public class HookMethodResolver {
+
+    public static Class artMethodClass;
+
+    public static Field resolvedMethodsField;
+    public static Field dexCacheField;
+    public static Field dexMethodIndexField;
+    public static Field artMethodField;
+
+    public static boolean canResolvedInJava = false;
+
+    public static long resolvedMethodsAddress = 0;
+    public static int dexMethodIndex = 0;
+
+    public static void init() {
+        checkSupport();
+    }
+
+    private static void checkSupport() {
+        try {
+            Method testMethod = HookMethodResolver.class.getDeclaredMethod("init");
+            dexMethodIndexField = getField(Method.class, "dexMethodIndex");
+            dexMethodIndex = (int) dexMethodIndexField.get(testMethod);
+            dexCacheField = getField(Class.class, "dexCache");
+            Object dexCache = dexCacheField.get(testMethod.getDeclaringClass());
+            resolvedMethodsField = getField(dexCache.getClass(), "resolvedMethods");
+            Object resolvedMethods = resolvedMethodsField.get(dexCache);
+            if (resolvedMethods instanceof Long) {
+                canResolvedInJava = false;
+                resolvedMethodsAddress = (long) resolvedMethods;
+            } else if (resolvedMethods instanceof long[]) {
+                canResolvedInJava = true;
+            } else if (hasJavaArtMethod() && resolvedMethods instanceof Object[]) {
+                canResolvedInJava = true;
+            } else {
+                canResolvedInJava = false;
+            }
+            if (canResolvedInJava) {
+                artMethodField = getField(Method.class, "artMethod");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void resolveMethod(Method hook, Method backup) {
+        if (canResolvedInJava && artMethodField != null) {
+            // in java
+            try {
+                resolveInJava(hook, backup);
+            } catch (Exception e) {
+                // in native
+                resolveInNative(hook, backup);
+            }
+        } else {
+            // in native
+            resolveInNative(hook, backup);
+        }
+    }
+
+    private static void resolveInJava(Method hook, Method backup) throws Exception {
+        Object dexCache = dexCacheField.get(hook.getDeclaringClass());
+        int dexMethodIndex = (int) dexMethodIndexField.get(backup);
+        Object resolvedMethods = resolvedMethodsField.get(dexCache);
+
+        if (resolvedMethods instanceof long[]) {
+            long artMethod = (long) artMethodField.get(backup);
+            ((long[])resolvedMethods)[dexMethodIndex] = artMethod;
+        } else if (resolvedMethods instanceof Object[]) {
+            Object artMethod = artMethodField.get(backup);
+            ((Object[])resolvedMethods)[dexMethodIndex] = artMethod;
+        } else {
+            throw new UnsupportedOperationException("unsupport");
+        }
+    }
+
+    private static void resolveInNative(Method hook, Method backup) {
+        HookMain.ensureMethodCached(hook, backup);
+    }
+
+    public static Field getField(Class topClass, String fieldName) throws NoSuchFieldException {
+        while (topClass != null && topClass != Object.class) {
+            try {
+                Field field = topClass.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                return field;
+            } catch (Exception e) {
+            }
+            topClass = topClass.getSuperclass();
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+
+    public static boolean hasJavaArtMethod() {
+        if (artMethodClass != null)
+            return true;
+        try {
+            artMethodClass = Class.forName("java.lang.reflect.ArtMethod");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+}

--- a/library/src/main/jni/HookMain.c
+++ b/library/src/main/jni/HookMain.c
@@ -145,62 +145,6 @@ static int doBackupAndHook(void *targetMethod, void *hookMethod, void *backupMet
     }
 
     if (backupMethod) {// do method backup
-        if (SDKVersion <= ANDROID_O2) {
-            // update the cached method manually
-            // first we find the array of cached methods
-            void *dexCacheResolvedMethods = (void *) readAddr(
-                    (void *) ((char *) hookMethod +
-                              OFFSET_dex_cache_resolved_methods_in_ArtMethod));
-
-            // then we get the dex method index of the static backup method
-            unsigned int methodIndex = read32(
-                    (void *) ((char *) backupMethod + OFFSET_dex_method_index_in_ArtMethod));
-
-            // finally the addr of backup method is put at the corresponding location in cached methods array
-            if (SDKVersion == ANDROID_O2) {
-                // array of MethodDexCacheType is used as dexCacheResolvedMethods in Android 8.1
-                // struct:
-                // struct NativeDexCachePair<T> = { T*, size_t idx }
-                // MethodDexCachePair = NativeDexCachePair<ArtMethod> = { ArtMethod*, size_t idx }
-                // MethodDexCacheType = std::atomic<MethodDexCachePair>
-
-                // https://github.com/rk700/YAHFA/issues/91
-                // for Android 8.1, the MethodDexCacheType array is of limited size
-                // the remainder of method index mod array size is used for indexing
-                size_t slotIndex = methodIndex % kDexCacheMethodCacheSize;
-                LOGI("method index is %d, slot index id %d", methodIndex, slotIndex);
-
-                // any element could be overwritten since the array is of limited size
-                // so just malloc a new buffer used as cached methods array for hookMethod to resolve backupMethod
-                void *newCachedMethodsArray = calloc(kDexCacheMethodCacheSize, pointer_size * 2);
-
-                // the 0th entry of the array has method index as 1
-                unsigned int one = 1;
-                memcpy(newCachedMethodsArray + pointer_size, &one, 4);
-
-                // update the backupMethod addr in cached methods array
-                memcpy(newCachedMethodsArray + pointer_size * 2 * slotIndex,
-                       (&backupMethod),
-                       pointer_size
-                );
-                // update the backupMethod index in cached methods array
-                memcpy(newCachedMethodsArray + pointer_size * 2 * slotIndex + pointer_size,
-                       &methodIndex,
-                       4
-                );
-
-                // use the new buffer as cached methods array for hookMethod
-                memcpy(((char *) hookMethod) + OFFSET_dex_cache_resolved_methods_in_ArtMethod,
-                       (&newCachedMethodsArray),
-                       pointer_size);
-
-            } else {
-                memcpy((char *) dexCacheResolvedMethods + OFFSET_array_in_PointerArray +
-                       pointer_size * methodIndex,
-                       (&backupMethod),
-                       pointer_size);
-            }
-        }
 
         // have to copy the whole target ArtMethod here
         // if the target method calls other methods which are to be resolved
@@ -249,6 +193,65 @@ static int doBackupAndHook(void *targetMethod, void *hookMethod, void *backupMet
     return 0;
 }
 
+static int ensureMethodCached(void *hookMethod, void *backupMethod) {
+    if (SDKVersion <= ANDROID_O2) {
+        // update the cached method manually
+        // first we find the array of cached methods
+        void *dexCacheResolvedMethods = (void *) readAddr(
+                (void *) ((char *) hookMethod +
+                          OFFSET_dex_cache_resolved_methods_in_ArtMethod));
+
+        // then we get the dex method index of the static backup method
+        unsigned int methodIndex = read32(
+                (void *) ((char *) backupMethod + OFFSET_dex_method_index_in_ArtMethod));
+
+        // finally the addr of backup method is put at the corresponding location in cached methods array
+        if (SDKVersion == ANDROID_O2) {
+            // array of MethodDexCacheType is used as dexCacheResolvedMethods in Android 8.1
+            // struct:
+            // struct NativeDexCachePair<T> = { T*, size_t idx }
+            // MethodDexCachePair = NativeDexCachePair<ArtMethod> = { ArtMethod*, size_t idx }
+            // MethodDexCacheType = std::atomic<MethodDexCachePair>
+
+            // https://github.com/rk700/YAHFA/issues/91
+            // for Android 8.1, the MethodDexCacheType array is of limited size
+            // the remainder of method index mod array size is used for indexing
+            size_t slotIndex = methodIndex % kDexCacheMethodCacheSize;
+            LOGI("method index is %d, slot index id %d", methodIndex, slotIndex);
+
+            // any element could be overwritten since the array is of limited size
+            // so just malloc a new buffer used as cached methods array for hookMethod to resolve backupMethod
+            void *newCachedMethodsArray = calloc(kDexCacheMethodCacheSize, pointer_size * 2);
+
+            // the 0th entry of the array has method index as 1
+            unsigned int one = 1;
+            memcpy(newCachedMethodsArray + pointer_size, &one, 4);
+
+            // update the backupMethod addr in cached methods array
+            memcpy(newCachedMethodsArray + pointer_size * 2 * slotIndex,
+                   (&backupMethod),
+                   pointer_size
+            );
+            // update the backupMethod index in cached methods array
+            memcpy(newCachedMethodsArray + pointer_size * 2 * slotIndex + pointer_size,
+                   &methodIndex,
+                   4
+            );
+
+            // use the new buffer as cached methods array for hookMethod
+            memcpy(((char *) hookMethod) + OFFSET_dex_cache_resolved_methods_in_ArtMethod,
+                   (&newCachedMethodsArray),
+                   pointer_size);
+
+        } else {
+                memcpy((char *) dexCacheResolvedMethods + OFFSET_array_in_PointerArray +
+                       pointer_size * methodIndex,
+                       (&backupMethod),
+                       pointer_size);
+        }
+    }
+}
+
 jobject Java_lab_galaxy_yahfa_HookMain_findMethodNative(JNIEnv *env, jclass clazz,
                                                         jclass targetClass, jstring methodName,
                                                         jstring methodSig) {
@@ -289,4 +292,11 @@ jboolean Java_lab_galaxy_yahfa_HookMain_backupAndHookNative(JNIEnv *env, jclass 
     } else {
         return JNI_FALSE;
     }
+}
+
+
+void Java_lab_galaxy_yahfa_HookMain_ensureMethodCached(JNIEnv *env, jclass clazz,
+                                                           jobject hook,
+                                                           jobject backup) {
+    ensureMethodCached((void *) (*env)->FromReflectedMethod(env, hook), backup == NULL ? NULL : (void *) (*env)->FromReflectedMethod(env, backup));
 }


### PR DESCRIPTION
修复了 6.0 64位 dex_cache_resolved_methods 偏移错误的问题

优先修改 java 层 Method -> Class -> DexCache -> resolvedMethods 进行替代

Java 层 resolvedMethods 映射到 ART 层 mirror 内的 dex_cache_resolved_methods