### PR TITLE
 Created HookAnnotation, an easier way to define hooks

### DIFF
--- a/library/src/androidTest/java/lab/galaxy/yahfa/HookingTest.java
+++ b/library/src/androidTest/java/lab/galaxy/yahfa/HookingTest.java
@@ -50,10 +50,11 @@ public class HookingTest {
 
 
         //------------------------ AFTER HOOKING --------------------------------
-        HookMain.backupAndHook(
+        HookAnnotation.hookClass(InstanceHook.class);
+        /*HookMain.backupAndHook(
                 InstanceHook.class.getMethod("target", int.class),
                 InstanceHook.class.getMethod("hook", InstanceHook.class, int.class),
-                InstanceHook.class.getMethod("backup", InstanceHook.class, int.class));
+                InstanceHook.class.getMethod("backup", InstanceHook.class, int.class));*/
 
         Assert.assertEquals(5, hookedInstance.target(5));
         Assert.assertEquals(2, InstanceHook.targetCount);
@@ -90,10 +91,12 @@ public class HookingTest {
 
 
         //------------------------ AFTER HOOKING --------------------------------
+        HookAnnotation.hookClass(StaticHook.class);
+        /*
         HookMain.backupAndHook(
                 StaticHook.class.getMethod("target", int.class),
                 StaticHook.class.getMethod("hook", int.class),
-                StaticHook.class.getMethod("backup", int.class));
+                StaticHook.class.getMethod("backup", int.class));*/
 
         Assert.assertEquals(5, StaticHook.target(5));
         Assert.assertEquals(2, StaticHook.targetCount);
@@ -130,10 +133,11 @@ public class HookingTest {
 
 
         //------------------------ AFTER HOOKING --------------------------------
-        HookMain.backupAndHook(
+        HookAnnotation.hookClass(CtorHook.class);
+        /*HookMain.backupAndHook(
                 CtorHook.class.getConstructor(int.class),
                 CtorHook.class.getMethod("hook", CtorHook.class, int.class),
-                CtorHook.class.getMethod("backup", CtorHook.class, int.class));
+                CtorHook.class.getMethod("backup", CtorHook.class, int.class));*/
 
         ctorHook = new CtorHook(0);
 
@@ -161,11 +165,13 @@ public class HookingTest {
             targetCount++;
         }
 
+        @HookAnnotation.ConstructorHook
         public static void hook(CtorHook thiz, int arg) {
             hookCount++;
             backup(thiz, arg);
         }
 
+        @HookAnnotation.ConstructorBackup
         public static void backup(CtorHook thiz, int arg) {
             backupCount++;
             throw new UnsupportedOperationException("Stub!");
@@ -182,11 +188,13 @@ public class HookingTest {
             return arg;
         }
 
+        @HookAnnotation.StaticMethodHook(targetClass = StaticHook.class, methodName = "target")
         public static int hook(int arg) {
             hookCount++;
             return backup(arg);
         }
 
+        @HookAnnotation.StaticMethodBackup(targetClass = StaticHook.class, methodName = "target")
         public static int backup(int arg) {
             backupCount++;
             throw new UnsupportedOperationException("Stub!");
@@ -198,11 +206,13 @@ public class HookingTest {
         static int hookCount;
         static int backupCount;
 
+        @HookAnnotation.MethodHook(methodName = "target")
         public static int hook(InstanceHook thiz, int arg) {
             hookCount++;
             return backup(thiz, arg);
         }
 
+        @HookAnnotation.MethodBackup(methodName = "target")
         public static int backup(InstanceHook thiz, int arg) {
             backupCount++;
             throw new UnsupportedOperationException("Stub!");

--- a/library/src/androidTest/java/lab/galaxy/yahfa/HookingTest.java
+++ b/library/src/androidTest/java/lab/galaxy/yahfa/HookingTest.java
@@ -51,10 +51,6 @@ public class HookingTest {
 
         //------------------------ AFTER HOOKING --------------------------------
         HookAnnotation.hookClass(InstanceHook.class);
-        /*HookMain.backupAndHook(
-                InstanceHook.class.getMethod("target", int.class),
-                InstanceHook.class.getMethod("hook", InstanceHook.class, int.class),
-                InstanceHook.class.getMethod("backup", InstanceHook.class, int.class));*/
 
         Assert.assertEquals(5, hookedInstance.target(5));
         Assert.assertEquals(2, InstanceHook.targetCount);
@@ -92,11 +88,6 @@ public class HookingTest {
 
         //------------------------ AFTER HOOKING --------------------------------
         HookAnnotation.hookClass(StaticHook.class);
-        /*
-        HookMain.backupAndHook(
-                StaticHook.class.getMethod("target", int.class),
-                StaticHook.class.getMethod("hook", int.class),
-                StaticHook.class.getMethod("backup", int.class));*/
 
         Assert.assertEquals(5, StaticHook.target(5));
         Assert.assertEquals(2, StaticHook.targetCount);
@@ -134,10 +125,6 @@ public class HookingTest {
 
         //------------------------ AFTER HOOKING --------------------------------
         HookAnnotation.hookClass(CtorHook.class);
-        /*HookMain.backupAndHook(
-                CtorHook.class.getConstructor(int.class),
-                CtorHook.class.getMethod("hook", CtorHook.class, int.class),
-                CtorHook.class.getMethod("backup", CtorHook.class, int.class));*/
 
         ctorHook = new CtorHook(0);
 

--- a/library/src/main/java/lab/galaxy/yahfa/HookAnnotation.java
+++ b/library/src/main/java/lab/galaxy/yahfa/HookAnnotation.java
@@ -1,0 +1,176 @@
+package lab.galaxy.yahfa;
+
+import android.util.Log;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines hooks using annotated methods.
+ *
+ * Target class, method name and signature are automatically inferred from the hook when possible
+ */
+public class HookAnnotation {
+    public static final String TAG = HookAnnotation.class.getSimpleName();
+
+    public static final String HOOK_SUFFIX = "Hook";
+    public static final String BACKUP_SUFFIX = "Backup";
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface ConstructorHook {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodHook {
+        String methodName() default "";
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface StaticMethodHook {
+        Class<?> targetClass();
+        String methodName() default "";
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface ConstructorBackup {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodBackup {
+        String methodName() default "";
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface StaticMethodBackup {
+        Class<?> targetClass();
+        String methodName() default "";
+    }
+
+    public static void hookClass(Class cls) {
+        Map<Object, Method> hooks = new HashMap<>();
+        Map<Object, Method> backups = new HashMap<>();
+
+        for (Method m : cls.getDeclaredMethods()) {
+
+            if (m.getAnnotation(ConstructorHook.class) != null) {
+                try {
+                    ConstructorHook annotation = m.getAnnotation(ConstructorHook.class);
+                    Class targetClass = m.getParameterTypes()[0];
+                    Class[] argTypes = Arrays.copyOfRange(m.getParameterTypes(), 1, m.getParameterTypes().length);
+                    Constructor targetMethod = targetClass.getDeclaredConstructor(argTypes);
+                    hooks.put(targetMethod, m);
+                } catch (Exception e) {
+                    Log.e(TAG, "Cannot find target constructor for " + m, e);
+                }
+            }
+
+            if (m.getAnnotation(MethodHook.class) != null) {
+                try {
+                    MethodHook annotation = m.getAnnotation(MethodHook.class);
+                    Class targetClass = m.getParameterTypes()[0];
+                    String methodName = annotation.methodName().isEmpty() ? m.getName().replaceFirst(HOOK_SUFFIX + "$", "") : annotation.methodName();
+                    Class[] argTypes = Arrays.copyOfRange(m.getParameterTypes(), 1, m.getParameterTypes().length);
+                    Method targetMethod = targetClass.getDeclaredMethod(methodName, argTypes);
+                    if (Modifier.isStatic(targetMethod.getModifiers())) {
+                        throw new IllegalArgumentException("Target method is static: " + targetMethod);
+                    }
+                    hooks.put(targetMethod, m);
+                } catch (Exception e) {
+                    Log.e(TAG, "Cannot find target method for " + m, e);
+                }
+            }
+
+            if (m.getAnnotation(StaticMethodHook.class) != null) {
+                try {
+                    StaticMethodHook annotation = m.getAnnotation(StaticMethodHook.class);
+                    Class targetClass = annotation.targetClass();
+                    String methodName = annotation.methodName().isEmpty() ? m.getName().replaceFirst(HOOK_SUFFIX + "$", "") : annotation.methodName();
+                    Class[] argTypes = m.getParameterTypes();
+                    Method targetMethod = targetClass.getDeclaredMethod(methodName, argTypes);
+                    if (!Modifier.isStatic(targetMethod.getModifiers())) {
+                        throw new IllegalArgumentException("Target method is not static: " + targetMethod);
+                    }
+                    hooks.put(targetMethod, m);
+                } catch (Exception e) {
+                    Log.e(TAG, "Cannot find target method for " + m, e);
+                }
+            }
+
+            if (m.getAnnotation(ConstructorBackup.class) != null) {
+                try {
+                    ConstructorBackup annotation = m.getAnnotation(ConstructorBackup.class);
+                    Class targetClass = m.getParameterTypes()[0];
+                    Class[] argTypes = Arrays.copyOfRange(m.getParameterTypes(), 1, m.getParameterTypes().length);
+                    Constructor targetMethod = targetClass.getDeclaredConstructor(argTypes);
+                    backups.put(targetMethod, m);
+                } catch (Exception e) {
+                    Log.e(TAG, "Cannot find target constructor for " + m, e);
+                }
+            }
+
+            if (m.getAnnotation(MethodBackup.class) != null) {
+                try {
+                    MethodBackup annotation = m.getAnnotation(MethodBackup.class);
+                    Class targetClass = m.getParameterTypes()[0];
+                    String methodName = annotation.methodName().isEmpty() ? m.getName().replaceFirst(BACKUP_SUFFIX + "$", "") : annotation.methodName();
+                    Class[] argTypes = Arrays.copyOfRange(m.getParameterTypes(), 1, m.getParameterTypes().length);
+                    Method targetMethod = targetClass.getDeclaredMethod(methodName, argTypes);
+                    if (Modifier.isStatic(targetMethod.getModifiers())) {
+                        throw new IllegalArgumentException("Target method is static: " + targetMethod);
+                    }
+                    backups.put(targetMethod, m);
+                } catch (Exception e) {
+                    Log.e(TAG, "Cannot find target method for " + m, e);
+                }
+            }
+
+            if (m.getAnnotation(StaticMethodBackup.class) != null) {
+                try {
+                    StaticMethodBackup annotation = m.getAnnotation(StaticMethodBackup.class);
+                    Class targetClass = annotation.targetClass();
+                    String methodName = annotation.methodName().isEmpty() ? m.getName().replaceFirst(BACKUP_SUFFIX + "$", "") : annotation.methodName();
+                    Class[] argTypes = m.getParameterTypes();
+                    Method targetMethod = targetClass.getDeclaredMethod(methodName, argTypes);
+                    if (!Modifier.isStatic(targetMethod.getModifiers())) {
+                        throw new IllegalArgumentException("Target method is not static: " + targetMethod);
+                    }
+                    backups.put(targetMethod, m);
+                } catch (Exception e) {
+                    Log.e(TAG, "Cannot find target method for " + m, e);
+                }
+            }
+        }
+
+        for (Object target : hooks.keySet()) {
+            Method hook = hooks.get(target);
+            Method backup = backups.get(target);
+            Throwable err = null;
+            try {
+                HookMain.backupAndHook(target, hook, backup);
+                Log.i(TAG, "Hooked " + target + ": hook=" + hook + (backup == null ? "" : ", backup=" + backup));
+            } catch (Throwable t) {
+                Log.e(TAG, "Failed to hooked " + target + ": hook=" + hook + (backup == null ? "" : ", backup=" + backup), t);
+            }
+        }
+
+        for (Object target : backups.keySet()) {
+            if (!hooks.containsKey(target)) {
+                Log.w(TAG, "Failed to install backup " + backups.get(target) + " on " + target + " because there is no matching hook");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Once again, thank you for the great library.

I've been using this helper syntax to define my hooks, and I think it's easier to use than the Plugins YAHFA currently supports, I hope you find it useful :)

---

When calling `HookAnnotation.hookClass(SomeClass.class)`, `SomeClass` is scanned for methods containing `@ConstructorHook`, `@ConstructorBackup`, `@MethodHook`, `@MethodBackup`, `@StaticMethodHook` and `@StaticMethodBackup`, and calls `HookMain.backupAndHook()` internally, taking away all the boring part of dealing with reflection, method signatures, etc.

The unit tests have been updated to use `HookAnnotation` instead of calling `HookMain` directly, which tests the new code without losing coverage.